### PR TITLE
Add support for environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ For more details, see Docker's notes here: https://success.docker.com/article/ho
        still running
  - [ ] support PID file based (bash) process state identification
  - [x] remote command execution (for "bash/remote" mode)
- - [ ] file watching and remote synchronization
- - [ ] remote dev mode constraints (initial setup, command hooks - i.e. npm
+ - [x] file watching and remote synchronization
+ - [x] remote dev mode constraints (initial setup, command hooks - i.e. npm
        install after `package[-lock].json` changes)
  - [ ] debug log mode
- - [ ] support volume mounting and envvar files for "docker/*" modes
+ - [x] support volume mounting and envvar files for "docker/*" modes
 
 

--- a/slot.go
+++ b/slot.go
@@ -31,9 +31,10 @@ type Provider struct {
 	WorkingDir string `hcl:"workingDir"`
 	Cmd        string `hcl:"cmd"`
 
-	Image   string   `hcl:"image"`
-	Ports   []string `hcl:"ports"`
-	Volumes []string `hcl:"volumes"`
+	Image       string   `hcl:"image"`
+	Ports       []string `hcl:"ports"`
+	Volumes     []string `hcl:"volumes"`
+	Environment []string `hcl:"environment"`
 
 	Remote   RemoteInfo    `hcl:"remote"`
 	Handlers []HandlerInfo `hcl:"handler"`
@@ -167,6 +168,7 @@ func (s *Slot) startDockerInternal(u *Unit, ctxt *ishell.Context, remote bool) e
 
 	resp, err := cli.ContainerCreate(ctx, &container.Config{
 		Image: image,
+		Env:   s.Provider.Environment,
 	}, hostConfig, nil, u.Name)
 	if err != nil {
 		return err


### PR DESCRIPTION
Adds support for environment variables in docker/* providers:
```
provider {
  type = "docker/remote"
  image = "mongo:3.6.14"
  
  environment = ["KEY=value"]
}
```