### PR TITLE
Add group support and improve start/stop checks

### DIFF
--- a/status.go
+++ b/status.go
@@ -18,6 +18,15 @@ type Status struct {
 	lock              *sync.Mutex
 }
 
+type UnitStatus int
+
+const (
+	NotStarted UnitStatus = iota
+	Running
+	Stopped
+	Crashed
+)
+
 func (s Status) String() string {
 	var status string
 	switch s.CurrentStatus {


### PR DESCRIPTION
This adds support for the `groups` array in unit definitions like:
```
unit {
  name = "app"
  groups = ["all", "services"]

}
```

That lets us start groups of units at the same time. In addition, add
some checks when starting/stopping services to see if they're already
running/stopped so we don't throw errors to the console.

Fixes #15 