### PR TITLE
Unset unit status if Docker container doesn't exist

### DIFF
--- a/unit.go
+++ b/unit.go
@@ -99,6 +99,9 @@ func (u *Unit) SavePIDFile(c *exec.Cmd) error {
 }
 
 func (u *Unit) ProcessStatus() string {
+	slot, _ := u.identifySlot()
+	u.populateDockerStatus(slot)
+
 	if u.Status == nil {
 		return NOT_STARTED
 	}
@@ -218,6 +221,10 @@ func (u *Unit) populateDockerStatus(slot *Slot) error {
 
 	if _, err = cli.ContainerInspect(ctx, u.Name); err != nil {
 		if client.IsErrNotFound(err) {
+			if u.Status != nil {
+				u.Status = nil
+			}
+
 			return nil
 		}
 		return err


### PR DESCRIPTION
This resolves #22.

## Problem

Glorious checks a unit's Docker status only when glorious initially loads. If you manually remove the unit's container outside of glorious, then glorious will incorrectly say the unit's status is "running". The unit's status will only become correct after you restart glorious.

### Reproduce

The following steps refer to a unit named "foo". Replace it with any other Docker unit declared in your glorious config.

1. Run `start foo` in glorious.
2. Run `status` to see that foo has the status "running".
3. Outside of glorious, run `docker rm $(docker ps -f name=foo -aq) -f` to remove foo's container.
4. In glorious, run `status` to see that foo is supposedly still running.
5. Restart glorious.
6. Run `status` to see that foo is "not started".

## Solution

In `unit.populateDockerStatus`, unset `unit.Status` if the unit's container isn't found. Also, run `unit.populateDockerStatus` when the unit's status is checked.

### Caveats

- Stopping a unit now causes its status to be "not started".
   - But is that bad? Previously, running `stop <unit>` would cause its status to become "stopped". But restarting glorious would cause its status to become "not started". Since the "stopped" and "not started" statuses were maybe used interchangeably, an argument could be made for deprecating one of them. But that may be for a discussion outside of this PR.